### PR TITLE
Ignore empty values during metadata combine

### DIFF
--- a/file_scraper/utils.py
+++ b/file_scraper/utils.py
@@ -151,7 +151,8 @@ def combine_metadata(stream, indexed_metadata, lose=None, important=None):
         incomplete_stream = stream[stream_index]
 
         for key in incomplete_stream.keys():
-            if key not in metadata_dict or metadata_dict[key] is None:
+            # skip missing values and values that are None or empty strings
+            if key not in metadata_dict or not metadata_dict[key]:
                 continue
 
             if incomplete_stream[key] in lose:

--- a/file_scraper/utils.py
+++ b/file_scraper/utils.py
@@ -151,8 +151,11 @@ def combine_metadata(stream, indexed_metadata, lose=None, important=None):
         incomplete_stream = stream[stream_index]
 
         for key in incomplete_stream.keys():
-            # skip missing values and values that are None or empty strings
-            if key not in metadata_dict or not metadata_dict[key]:
+            if key not in metadata_dict or metadata_dict[key] is None:
+                continue
+
+            # if we already have a value and are trying to update with an empty string, just leave it
+            if incomplete_stream[key] and incomplete_stream[key] != '' and not metadata_dict[key]:
                 continue
 
             if incomplete_stream[key] in lose:


### PR DESCRIPTION
It should be entirely safe to skip empty string and other "false-y" values during metdata combine, and not just values that are explicitly None.